### PR TITLE
Allow opts to be passed upstream to `cookie.parse`

### DIFF
--- a/src/cookie.js
+++ b/src/cookie.js
@@ -9,8 +9,8 @@ function _isResWritable() {
   return _res && !_res.headersSent;
 }
 
-export function load(name, doNotParse) {
-  const cookies = IS_NODE ? _rawCookie : cookie.parse(document.cookie);
+export function load(name, doNotParse, opt) {
+  const cookies = IS_NODE ? _rawCookie : cookie.parse(document.cookie, opt);
   let cookieVal = cookies && cookies[name];
 
   if (typeof doNotParse === 'undefined') {


### PR DESCRIPTION
`cookie` - The signature of `cookie.parse` is: `parse(str, options)`
`react-cookie` - The signature of `cookie.load` is: `load(name, doNotParse)`

Proposed signature change is: `load(name, doNotParse, opt)` to remain backwards-compatible.